### PR TITLE
Fix test failure introduced by a 'apply security signature method in …

### DIFF
--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -144,11 +144,10 @@ class RequestTest < Test::Unit::TestCase
         assert params['Signature']
         assert params['SigAlg'] == XMLSecurity::Document::SHA1
 
-        # signature_method only affects the embedeed signature
         settings.security[:signature_method] = XMLSecurity::Document::SHA256
         params = OneLogin::RubySaml::Logoutrequest.new.create_params(settings)
         assert params['Signature']
-        assert params['SigAlg'] == XMLSecurity::Document::SHA1
+        assert params['SigAlg'] == XMLSecurity::Document::SHA256
       end
     end
 


### PR DESCRIPTION
Test must be run with ruby 2.1.* version.
Use the following command: `rake test`

This PR fixes a test on logout request which be introduced by 7f499399dcff1c5380b7919c5d1735b92d756284